### PR TITLE
Switch from BSD-3 to MIT license

### DIFF
--- a/.vscode/tools/setup_vscode.py
+++ b/.vscode/tools/setup_vscode.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This script sets up the vs-code settings for the orbit project.
 
 This script merges the python.analysis.extraPaths from the "_isaac_sim/.vscode/settings.json" file into

--- a/LICENCE
+++ b/LICENCE
@@ -1,30 +1,19 @@
-Copyright (c) 2022-2024, The ORBIT Project Developers.
+Copyright (c) 2024, The ORBIT Project Developers.
 
-All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-SPDX-License-Identifier: BSD-3-Clause
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software without
-   specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python](https://img.shields.io/badge/python-3.10-blue.svg)](https://docs.python.org/3/whatsnew/3.10.html)
 [![Linux platform](https://img.shields.io/badge/platform-linux--64-orange.svg)](https://releases.ubuntu.com/20.04/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
+[![License](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/license/mit)
 
 ## Overview
 

--- a/orbit/ext_template/__init__.py
+++ b/orbit/ext_template/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """
 Python module serving as a project/extension template.
 """

--- a/orbit/ext_template/tasks/__init__.py
+++ b/orbit/ext_template/tasks/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Package containing task implementations for various robotic environments."""
 
 import os

--- a/orbit/ext_template/tasks/locomotion/__init__.py
+++ b/orbit/ext_template/tasks/locomotion/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Locomotion environments for legged robots."""
 
 from .velocity import *  # noqa

--- a/orbit/ext_template/tasks/locomotion/velocity/__init__.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Locomotion environments with velocity-tracking commands.
 
 These environments are based on the `legged_gym` environments provided by Rudin et al.

--- a/orbit/ext_template/tasks/locomotion/velocity/config/__init__.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/config/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Configurations for velocity-based locomotion environments."""
 
 # We leave this file empty since we don't want to expose any configs in this package directly.

--- a/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/__init__.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import gymnasium as gym
 
 from . import agents, flat_env_cfg, rough_env_cfg

--- a/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/agents/__init__.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/agents/__init__.py
@@ -1,6 +1,1 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from . import rsl_rl_cfg  # noqa: F401, F403

--- a/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/agents/rsl_rl_cfg.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/agents/rsl_rl_cfg.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from omni.isaac.orbit.utils import configclass
 from omni.isaac.orbit_tasks.utils.wrappers.rsl_rl import (
     RslRlOnPolicyRunnerCfg,

--- a/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/flat_env_cfg.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/flat_env_cfg.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from omni.isaac.orbit.utils import configclass
 
 from .rough_env_cfg import AnymalDRoughEnvCfg

--- a/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/rough_env_cfg.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/config/anymal_d/rough_env_cfg.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from omni.isaac.orbit.utils import configclass
 
 from orbit.ext_template.tasks.locomotion.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg

--- a/orbit/ext_template/tasks/locomotion/velocity/mdp/__init__.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/mdp/__init__.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """This sub-module contains the functions that are specific to the locomotion environments."""
 
 from omni.isaac.orbit.envs.mdp import *  # noqa: F401, F403

--- a/orbit/ext_template/tasks/locomotion/velocity/mdp/curriculums.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/mdp/curriculums.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Common functions that can be used to create curriculum for the learning environment.
 
 The functions can be passed to the :class:`omni.isaac.orbit.managers.CurriculumTermCfg` object to enable

--- a/orbit/ext_template/tasks/locomotion/velocity/mdp/rewards.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/mdp/rewards.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import torch

--- a/orbit/ext_template/tasks/locomotion/velocity/velocity_env_cfg.py
+++ b/orbit/ext_template/tasks/locomotion/velocity/velocity_env_cfg.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import math

--- a/orbit/ext_template/ui_extension_example.py
+++ b/orbit/ext_template/ui_extension_example.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 import omni.ext
 import omni.ui as ui
 

--- a/scripts/rsl_rl/cli_args.py
+++ b/scripts/rsl_rl/cli_args.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 from __future__ import annotations
 
 import argparse

--- a/scripts/rsl_rl/play.py
+++ b/scripts/rsl_rl/play.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to play a checkpoint if an RL agent from RSL-RL."""
 
 """Launch Isaac Sim Simulator first."""

--- a/scripts/rsl_rl/train.py
+++ b/scripts/rsl_rl/train.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Script to train RL agent with RSL-RL."""
 
 """Launch Isaac Sim Simulator first."""

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,3 @@
-# Copyright (c) 2022-2024, The ORBIT Project Developers.
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-
 """Installation script for the 'orbit.ext_template' python package."""
 
 import os


### PR DESCRIPTION
BSD-3-Clause does require a bit more in terms of copying the license text (including the disclaimer), which is why we intend to switch licensing for the extension template.